### PR TITLE
feat: Add new flags and ENV support for new options

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -38,4 +38,3 @@ include::doc/usage.adoc[]
 ----
 include::doc/usage_build.adoc[]
 ----
-

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -43,12 +43,24 @@ fn main() {
 
 			let path = fs::canonicalize(&build_opts.path).unwrap();
 			format!(
-				"docker run --name srtool --rm -e PACKAGE={package} -v {dir}:/build -v {tmpdir}cargo:/cargo-home {image}:{tag} build",
+				"docker run --name srtool --rm \
+					-e PACKAGE={package} \
+					-e RUNTIME_DIR={runtime_dir} \
+					-e BUILD_OPTS={c_build_opts} \
+					-e DEFAULT_FEATURES={default_features} \
+					-e PROFILE={profile} \
+					-v {dir}:/build \
+					-v {tmpdir}cargo:/cargo-home \
+					{image}:{tag} build",
 				package = build_opts.package,
 				dir = path.display(),
 				tmpdir = env::temp_dir().display(),
 				image = IMAGE,
 				tag = tag,
+				runtime_dir = build_opts.runtime_dir.display(),
+				c_build_opts = build_opts.build_opts.unwrap_or(String::from("")),
+				default_features = build_opts.default_features.unwrap_or(String::from("")),
+				profile = build_opts.profile,
 			)
 		}
 		SubCommand::Info(info_opts) => {
@@ -67,7 +79,7 @@ fn main() {
 		}
 	};
 
-	// println!("command = {:?}", command);
+	debug!("command = {:?}", command);
 
 	if cfg!(target_os = "windows") {
 		Command::new("cmd").args(&["/C", command.as_str()]).output().expect("failed to execute process");

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -37,11 +37,36 @@ pub enum SubCommand {
 #[derive(Clap)]
 pub struct BuildOpts {
 	/// Provide the runtime such as kusama-runtime, polkadot-runtime, etc...
-	#[clap(long, short)]
+	#[clap(long, short, env = "PACKAGE")]
 	pub package: String,
 
+	/// By default, srtool will work in the current folder.
+	/// If your project is located in another location, you can pass it here.
 	#[clap(index = 1, default_value = ".")]
 	pub path: PathBuf,
+
+	/// If your runtime is not in the standard location runtime/<chain_name>
+	/// you can pass this args to help srtool find it.
+	#[clap(short, long, env = "RUNTIME_DIR")]
+	pub runtime_dir: PathBuf,
+
+	/// You may pass options to cargo directly here. WARNING, if you pass
+	/// this value, the automatic build options for Kusama and Polkadot will
+	/// not be passed and you need to take care of them manually.
+	/// In general, you should never use this option unless you HAVE to.
+	#[clap(long, env = "BUILD_OPTS")]
+	pub build_opts: Option<String>,
+
+	/// Passing this is less involved than passing BUILD_OPTS. It allows
+	/// changing the list of default features while keeping the automatic
+	/// features detection. This value is useless if BUILD_OPTS is set.
+	#[clap(long, env = "DEFAULT_FEATURES")]
+	pub default_features: Option<String>,
+
+	/// The default profile to build runtimes is always `release`.
+	/// You may override the default with this flag.
+	#[clap(long, env = "PROFILE", default_value = "release")]
+	pub profile: String,
 }
 
 /// Info opts


### PR DESCRIPTION
The following ENV can now be passed either as ENV or flag:
- PACKAGE
- RUNTIME_DIR
- BUILD_OPTS
- DEFAULT_FEATURES
- PROFILE

They are passed along to the srtool container as ENV.

fix #2