### PR TITLE
Add cli option to build WASM with no std

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -66,6 +66,7 @@ fn main() -> Result<(), SrtoolError> {
 				if !no_cache { format!("-v {tmpdir}:/cargo-home", tmpdir = tmpdir.display()) } else { String::new() };
 			let root_opts = if build_opts.root { "-u root" } else { "" };
 			let verbose_opts = if build_opts.verbose { "-e VERBOSE=1" } else { "" };
+			let no_wasm_std = if build_opts.no_wasm_std { "-e WASM_BUILD_STD=0" } else { "" };
 
 			debug!("engine: '{engine}'");
 			debug!("app: '{app}'");
@@ -76,6 +77,7 @@ fn main() -> Result<(), SrtoolError> {
 			debug!("tmpdir: '{}'", &tmpdir.display());
 			debug!("digest: '{digest}'");
 			debug!("no-cache: '{}'", no_cache);
+			debug!("no-wasm-std: '{no_wasm_std}'");
 
 			let path = fs::canonicalize(&build_opts.path).unwrap();
 
@@ -95,6 +97,7 @@ fn main() -> Result<(), SrtoolError> {
 				-e PROFILE={profile} \
 				-e IMAGE={digest} \
 				{verbose_opts} \
+				{no_wasm_std} \
 				-v {dir}:/build \
 				{cache_mount} \
 				{root_opts} \

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -126,6 +126,11 @@ pub struct BuildOpts {
 	/// Run the build script using the verbose option
 	#[clap(long)]
 	pub verbose: bool,
+
+	/// Passing this flag solves the issue when there are no standard library sources found in WASM
+	/// runtime compilation.
+	#[clap(long)]
+	pub no_wasm_std: bool,
 }
 
 /// Info opts


### PR DESCRIPTION
When using `srtool-cli` locally it fails with:
```
Cannot compile the WASM runtime: no standard library sources found!
...
```

This PR adds a cli flag which, when passed, passes `WASM_BUILD_STD=0` to the engine run command. The current default functionality is retained when the flag is not passed.