### PR TITLE
Add `--local-registry` and `--tag` flags

### DIFF
--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -15,6 +15,9 @@ pub enum SrtoolError {
 
 	#[error("UTF8 error: {0}")]
 	UTF8(std::string::FromUtf8Error),
+
+	#[error("EnvVar error: {0}")]
+	Var(#[from] std::env::VarError),
 }
 
 impl From<std::io::Error> for SrtoolError {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -82,9 +82,8 @@ fn main() -> Result<(), SrtoolError> {
 				let cargo_home = Path::new(&cargo_home).canonicalize()?;
 				let cargo_home = cargo_home.display();
 				format!(
-					"{} {}",
-					format!("-v {cargo_home}/git:/home/{user}/.cargo/git"),
-					format!("-v {cargo_home}/registry:/home/{user}/.cargo/registry"),
+					"-v {cargo_home}/git:/home/{user}/.cargo/git \
+					-v {cargo_home}/registry:/home/{user}/.cargo/registry"
 				)
 			} else {
 				"".to_string()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,7 +3,7 @@ use clap::{crate_version, Parser};
 use log::{debug, info};
 use opts::*;
 use srtool_lib::*;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::{env, fs};
 
@@ -41,7 +41,14 @@ fn main() -> Result<(), SrtoolError> {
 	debug!("Checking what is the latest available tag...");
 	const ONE_HOUR: u64 = 60 * 60;
 
-	let tag = get_image_tag(Some(ONE_HOUR)).expect("Issue getting the image tag");
+	let tag = if let Some(tag) = opts.tag {
+		tag
+	} else if let Ok(tag) = env::var("SRTOOL_TAG") {
+		info!("using tag from ENV: {:?}", tag);
+		tag
+	} else {
+		get_image_tag(Some(ONE_HOUR)).expect("Issue getting the image tag")
+	};
 
 	info!("Using {image}:{tag}");
 
@@ -64,9 +71,24 @@ fn main() -> Result<(), SrtoolError> {
 			let no_cache = if opts.engine == ContainerEngine::Podman { true } else { build_opts.no_cache };
 			let cache_mount =
 				if !no_cache { format!("-v {tmpdir}:/cargo-home", tmpdir = tmpdir.display()) } else { String::new() };
-			let root_opts = if build_opts.root { "-u root" } else { "" };
+
+			let root_opts = if build_opts.root { "-u root" } else { "-u builder" };
 			let verbose_opts = if build_opts.verbose { "-e VERBOSE=1" } else { "" };
 			let no_wasm_std = if build_opts.no_wasm_std { "-e WASM_BUILD_STD=0" } else { "" };
+
+			let local_registry = if build_opts.use_local_registry {
+				let user = if build_opts.root { "root" } else { "builder" };
+				let cargo_home = std::env::var("CARGO_HOME")?;
+				let cargo_home = Path::new(&cargo_home).canonicalize()?;
+				let cargo_home = cargo_home.display();
+				format!(
+					"{} {}",
+					format!("-v {cargo_home}/git:/home/{user}/.cargo/git"),
+					format!("-v {cargo_home}/registry:/home/{user}/.cargo/registry"),
+				)
+			} else {
+				"".to_string()
+			};
 
 			debug!("engine: '{engine}'");
 			debug!("app: '{app}'");
@@ -99,6 +121,7 @@ fn main() -> Result<(), SrtoolError> {
 				{verbose_opts} \
 				{no_wasm_std} \
 				-v {dir}:/build \
+				{local_registry} \
 				{cache_mount} \
 				{root_opts} \
 				{image}:{tag} build{app}{json}"

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -20,6 +20,9 @@ pub struct Opts {
 	#[clap(short, long, default_value = "docker.io/paritytech/srtool", global = true)]
 	pub image: String,
 
+	#[clap(long, global = true)]
+	pub tag: Option<String>,
+
 	/// This option is DEPRECATED and has no effect
 	#[clap(short, long)]
 	pub json: bool,
@@ -131,6 +134,9 @@ pub struct BuildOpts {
 	/// runtime compilation.
 	#[clap(long)]
 	pub no_wasm_std: bool,
+
+	#[clap(long)]
+	pub use_local_registry: bool,
 }
 
 /// Info opts

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -3,7 +3,6 @@ mod error;
 use error::*;
 use log::{debug, info};
 use std::{
-	env,
 	fs::{self, File},
 	io::Write,
 	process::Command,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -25,12 +25,6 @@ pub fn fetch_image_tag() -> Result<String> {
 /// Get the latest image. it is fetched from cache we have a version that is younger than `cache_validity` in seconds.
 #[allow(clippy::result_large_err)]
 pub fn get_image_tag(cache_validity: Option<u64>) -> Result<String> {
-	let env_tag = env::var("SRTOOL_TAG");
-	if let Ok(tag) = env_tag {
-		info!("using tag from ENV: {:?}", tag);
-		return Ok(tag);
-	}
-
 	let cache_location = std::env::temp_dir().join(CACHE_FILE);
 	debug!("cache_location = {:?}", cache_location);
 


### PR DESCRIPTION
Some context:

I need to build a custom srtool image because I need an OpenCL library for the compilation process, as such, I need to add the install command to the srtool image. I used `just build` there and noticed that it always tries to fetch the image from docker.io which is less than ideal.

I've added the two flags in the title:
* `--local-registry` — allows users to use volumes to share the local registry with Docker, the idea is to speed up builds but in this case I'm not 100% sure it helps A TON
* `--tag` — allows users to set the tag, this is useful if you're building your custom docker image

I've moved the `SRTOOL_TAG` env var OUT of the library since it is essentially hidden control flow when used there. 
We can also replace the tag flag with a split on `:` to detect a tag on a Docker image.

