### PR TITLE
refactor: migrate `ContainerEngine` from `cli` to `srtool-lib` for reusability

### DIFF
--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -1,6 +1,7 @@
 use std::string::FromUtf8Error;
 
 use thiserror::Error;
+use srtool_lib::SrtoolLibError;
 
 #[derive(Error, Debug)]
 pub enum SrtoolError {
@@ -27,4 +28,16 @@ impl From<FromUtf8Error> for SrtoolError {
 	fn from(error: FromUtf8Error) -> Self {
 		SrtoolError::UTF8(error)
 	}
+}
+
+impl From<SrtoolLibError> for SrtoolError {
+    fn from(error: SrtoolLibError) -> Self {
+        match error {
+            SrtoolLibError::UnknownContainerEngine(opt) => SrtoolError::UnknownContainerEngine(opt),
+            SrtoolLibError::CtrlCSetup => SrtoolError::CtrlCSetup,
+            SrtoolLibError::IO(e) => SrtoolError::IO(e),
+            SrtoolLibError::UTF8(e) => SrtoolError::UTF8(e),
+            _ => unreachable!("Skipping SrtoolLibError::HttpRequest as it's not relevant"),
+        }
+    }
 }

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -1,7 +1,7 @@
 use std::string::FromUtf8Error;
 
-use thiserror::Error;
 use srtool_lib::SrtoolLibError;
+use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum SrtoolError {
@@ -31,13 +31,13 @@ impl From<FromUtf8Error> for SrtoolError {
 }
 
 impl From<SrtoolLibError> for SrtoolError {
-    fn from(error: SrtoolLibError) -> Self {
-        match error {
-            SrtoolLibError::UnknownContainerEngine(opt) => SrtoolError::UnknownContainerEngine(opt),
-            SrtoolLibError::CtrlCSetup => SrtoolError::CtrlCSetup,
-            SrtoolLibError::IO(e) => SrtoolError::IO(e),
-            SrtoolLibError::UTF8(e) => SrtoolError::UTF8(e),
-            _ => unreachable!("Skipping SrtoolLibError::HttpRequest as it's not relevant"),
-        }
-    }
+	fn from(error: SrtoolLibError) -> Self {
+		match error {
+			SrtoolLibError::UnknownContainerEngine(opt) => SrtoolError::UnknownContainerEngine(opt),
+			SrtoolLibError::CtrlCSetup => SrtoolError::CtrlCSetup,
+			SrtoolLibError::IO(e) => SrtoolError::IO(e),
+			SrtoolLibError::UTF8(e) => SrtoolError::UTF8(e),
+			_ => unreachable!("Skipping SrtoolLibError::HttpRequest as it's not relevant"),
+		}
+	}
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -25,6 +25,9 @@ fn main() -> Result<(), SrtoolError> {
 	let opts: Opts = Opts::parse();
 	let image = &opts.image;
 	let engine = opts.engine;
+	if engine == ContainerEngine::Docker {
+		println!("WARNING: You are using docker. We recommend using podman instead.");
+	}
 
 	if opts.no_cache {
 		let _ = clear_cache();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,16 +2,13 @@ mod opts;
 use clap::{crate_version, Parser};
 use log::{debug, info};
 use opts::*;
-use srtool_lib::*;
+use srtool_lib::{clear_cache, get_image_digest, get_image_tag, ContainerEngine};
 use std::path::PathBuf;
 use std::process::Command;
 use std::{env, fs};
 
 mod error;
 use error::SrtoolError;
-
-mod container_engine;
-use container_engine::ContainerEngine;
 
 fn handle_exit(engine: &ContainerEngine) {
 	println!("Killing srtool container, your build was not finished...");

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -2,11 +2,12 @@ use clap::{crate_authors, crate_version, Parser, Subcommand};
 use std::convert::TryFrom;
 use std::env;
 use std::path::PathBuf;
+use srtool_lib::ContainerEngine;
 
-use crate::{error, ContainerEngine};
+use crate::error;
 
 fn parse_container_engine(s: &str) -> Result<ContainerEngine, error::SrtoolError> {
-	ContainerEngine::try_from(s)
+	ContainerEngine::try_from(s).map_err(Into::into)
 }
 
 /// Control the srtool docker container

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -1,8 +1,8 @@
 use clap::{crate_authors, crate_version, Parser, Subcommand};
+use srtool_lib::ContainerEngine;
 use std::convert::TryFrom;
 use std::env;
 use std::path::PathBuf;
-use srtool_lib::ContainerEngine;
 
 use crate::error;
 

--- a/lib/src/container_engine.rs
+++ b/lib/src/container_engine.rs
@@ -2,15 +2,18 @@ use std::{fmt::Display, process::Command};
 
 use crate::SrtoolLibError;
 
+/// Represents the container engine being used.
 #[derive(Clone, Copy, PartialEq)]
 pub enum ContainerEngine {
+	/// Represents the Docker container engine.
 	Docker,
+	/// Represents the Podman container engine.
 	Podman,
 }
 
 impl ContainerEngine {
 	/// Check whether you have Podman and/or Docker installed. The default will be Podman if both are present.
-	fn detect() -> Result<ContainerEngine, SrtoolLibError> {
+	pub fn detect() -> Result<ContainerEngine, SrtoolLibError> {
 		if let Ok(engine) = std::env::var("ENGINE") {
 			return ContainerEngine::try_from(engine.as_str());
 		}

--- a/lib/src/container_engine.rs
+++ b/lib/src/container_engine.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, process::Command};
 
-use crate::SrtoolError;
+use crate::SrtoolLibError;
 
 #[derive(Clone, Copy, PartialEq)]
 pub enum ContainerEngine {
@@ -10,7 +10,7 @@ pub enum ContainerEngine {
 
 impl ContainerEngine {
 	/// Check whether you have Podman and/or Docker installed. The default will be Podman if both are present.
-	fn detect() -> Result<ContainerEngine, SrtoolError> {
+	fn detect() -> Result<ContainerEngine, SrtoolLibError> {
 		if let Ok(engine) = std::env::var("ENGINE") {
 			return ContainerEngine::try_from(engine.as_str());
 		}
@@ -37,12 +37,12 @@ impl ContainerEngine {
 			}
 		}
 
-		Err(SrtoolError::UnknownContainerEngine(None))
+		Err(SrtoolLibError::UnknownContainerEngine(None))
 	}
 }
 
 impl TryFrom<&str> for ContainerEngine {
-	type Error = SrtoolError;
+	type Error = SrtoolLibError;
 
 	fn try_from(s: &str) -> Result<Self, Self::Error> {
 		match s.to_ascii_lowercase().as_str() {
@@ -52,7 +52,7 @@ impl TryFrom<&str> for ContainerEngine {
 				println!("WARNING: You are using docker. We recommend using podman instead.");
 				Ok(ContainerEngine::Docker)
 			}
-			_ => Err(SrtoolError::UnknownContainerEngine(Some(s.into()))),
+			_ => Err(SrtoolLibError::UnknownContainerEngine(Some(s.into()))),
 		}
 	}
 }

--- a/lib/src/container_engine.rs
+++ b/lib/src/container_engine.rs
@@ -63,3 +63,36 @@ impl Display for ContainerEngine {
 		}
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::env;
+
+	#[test]
+	fn detect_works() {
+		env::set_var("ENGINE", "docker");
+		assert!(ContainerEngine::detect().unwrap() == ContainerEngine::Docker);
+
+		env::set_var("ENGINE", "podman");
+		assert!(ContainerEngine::detect().unwrap() == ContainerEngine::Podman);
+		// Cleanup after test
+		env::remove_var("ENGINE");
+	}
+
+	#[test]
+	fn container_enginer_try_from_works() {
+		assert!(ContainerEngine::try_from("docker").unwrap() == ContainerEngine::Docker);
+		assert!(ContainerEngine::try_from("podman").unwrap() == ContainerEngine::Podman);
+		assert!(matches!(
+			ContainerEngine::try_from("invalid"),
+			Err(SrtoolLibError::UnknownContainerEngine(Some(_)))
+		));
+	}
+
+	#[test]
+	fn container_enginer_display_works() {
+		assert_eq!(ContainerEngine::Docker.to_string(), "docker");
+		assert_eq!(ContainerEngine::Podman.to_string(), "podman");
+	}
+}

--- a/lib/src/container_engine.rs
+++ b/lib/src/container_engine.rs
@@ -21,7 +21,6 @@ impl ContainerEngine {
 			if podman.to_lowercase().contains("podman") {
 				return Ok(ContainerEngine::Podman);
 			} else if podman.contains("docker") {
-				println!("WARNING: You have podman symlinked to docker. This is strange :)");
 				return Ok(ContainerEngine::Docker);
 			}
 		}
@@ -30,7 +29,6 @@ impl ContainerEngine {
 		if let Some(docker) = docker_output {
 			let docker = String::from_utf8_lossy(&docker.stdout);
 			if docker.to_lowercase().contains("docker") {
-				println!("WARNING: You are using docker. We recommend using podman instead.");
 				return Ok(ContainerEngine::Docker);
 			} else if docker.contains("podman") {
 				return Ok(ContainerEngine::Podman);

--- a/lib/src/container_engine.rs
+++ b/lib/src/container_engine.rs
@@ -87,10 +87,7 @@ mod tests {
 	fn container_enginer_try_from_works() {
 		assert!(ContainerEngine::try_from("docker").unwrap() == ContainerEngine::Docker);
 		assert!(ContainerEngine::try_from("podman").unwrap() == ContainerEngine::Podman);
-		assert!(matches!(
-			ContainerEngine::try_from("invalid"),
-			Err(SrtoolLibError::UnknownContainerEngine(Some(_)))
-		));
+		assert!(matches!(ContainerEngine::try_from("invalid"), Err(SrtoolLibError::UnknownContainerEngine(Some(_)))));
 	}
 
 	#[test]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,6 +1,9 @@
+mod container_engine;
 mod error;
 
-use error::*;
+pub use container_engine::ContainerEngine;
+pub use error::*;
+
 use log::{debug, info};
 use std::{
 	env,


### PR DESCRIPTION
We are integrating `srtool-lib` into our [pop-cli](https://github.com/r0gue-io/pop-cli) tool to build deterministic runtimes. Currently, `ContainerEngine` is part of the CLI, but migrating it into the library will allow external tools to reuse it without duplicating logic.

This PR includes the following changes:

- Moves `ContainerEngine` from the `cli` to `srtool-lib` for better modularity.
- Removes `println!` statements from the `ContainerEngine` module, relocating them to the CLI main (if still needed).
- Adds basic tests to `ContainerEngine`.
- Add public docs to the `ContainerEngine` module.

Closes https://github.com/chevdor/srtool-cli/issues/36